### PR TITLE
support for 7.5.2, not using automated installer

### DIFF
--- a/7.5.2-simple/Dockerfile
+++ b/7.5.2-simple/Dockerfile
@@ -1,0 +1,62 @@
+FROM ubuntu:trusty
+MAINTAINER Alkacon Software GmbH
+
+#
+# This Dockerfile installs a simple OpenCms demo system.
+# It downloads the OpenCms distro and installs it with all the standard demo modules.
+#
+# Use the following command to run:
+#  
+# docker run -d -p 8080:8080 -p 22000:22 alkacon/opencms-docker:7.5.2-simple
+# 
+
+# Variables used in the shell scripts loaded from the file system
+ENV ROOT_PWD=mypassword \
+	WEBAPPS_HOME=/var/lib/tomcat7/webapps \
+	OPENCMS_HOME=/var/lib/tomcat7/webapps/opencms \
+	CONFIG_FILE=/setup.properties
+
+RUN \
+# Update the apt packet repos
+    apt-get update && \ 
+
+# Install mysql, tomcat7 and other stuff we need
+    apt-get install -yq --no-install-recommends wget unzip openssh-server mysql-server tomcat7 && \
+
+# Clean up
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get autoremove && \
+    apt-get clean && \
+
+# SSH Setup, straight from the example on the Docker website
+    mkdir /var/run/sshd && \
+    echo "root:${ROOT_PWD}" | chpasswd && \
+    sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+# Create the mysqldump and preinstalled opencms tar gz
+COPY resources /
+
+RUN \
+# Fetch the OpenCms installation file and create the setup properties
+    wget -nv https://dl.dropboxusercontent.com/u/16438268/opencms-app.zip -O /opencms-app.zip && \
+    wget -nv https://dl.dropboxusercontent.com/u/16438268/opencms.sql.zip -O /opencms-sql.zip && \
+    chmod +x /opencms-*.sh && \
+    bash /opencms-create-properties.sh && \
+# Deploy the pre-installed app
+	unzip -d $WEBAPPS_HOME /opencms-app.zip && \
+    unzip /opencms-sql.zip && \
+# Start up mysql and set the password of the root user to "opencms"
+    service mysql start && \
+    mysqladmin -u root --password="" password "${ROOT_PWD}" && \
+# Create the Database and Extract and import the mysql dump
+	mysql -uroot -p$ROOT_PWD -e "create database opencms" && \
+	mysql -uroot -p$ROOT_PWD opencms < /opencms.sql && \
+
+# Clean up
+    chown -R tomcat7:tomcat7 ${OPENCMS_HOME} && \
+    rm /opencms-create-properties.sh ${CONFIG_FILE}
+
+# Run SSH, which allows us to connect to the dockerized OpenCms instance
+EXPOSE 8080 
+EXPOSE 22
+CMD ["/opencms-run.sh"]

--- a/7.5.2-simple/resource/opencms-create-properties.sh
+++ b/7.5.2-simple/resource/opencms-create-properties.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+OCSERVER="http://127.0.0.1:8080"
+HWADDR=$(cat /sys/class/net/eth0/address)
+
+DB_USER=root
+DB_PWD=$ROOT_PWD
+DB_DB=opencms
+DB_PRODUCT=mysql
+DB_URL="jdbc:mysql://localhost:3306/"
+DB_DRIVER=org.gjt.mm.mysql.Driver
+
+# Create setup.properties
+echo "OpenCms Setup: Writing configuration to '$CONFIG_FILE'"
+PROPERTIES="
+
+setup.webapp.path=$OPENCMS_HOME
+setup.default.webapp=
+setup.install.components=workplace,bootstrap,documentation
+setup.show.progress=true
+
+db.product=$DB_PRODUCT
+db.provider=$DB_PRODUCT
+db.create.user=$DB_USER
+db.create.pwd=$DB_PWD
+db.worker.user=$DB_USER
+db.worker.pwd=$DB_PWD
+db.connection.url=$DB_URL
+db.name=$DB_DB
+db.create.db=true
+db.create.tables=true
+db.dropDb=true
+db.default.tablespace=
+db.index.tablespace=
+db.jdbc.driver=$DB_DRIVER
+db.template.db=
+db.temporary.tablespace=
+
+server.url=$OCSERVER
+server.name=OpenCmsServer
+server.ethernet.address=$HWADDR
+server.servlet.mapping=
+
+"
+echo "$PROPERTIES" > $CONFIG_FILE || { echo "Error: Couldn't write to '$CONFIG_FILE'!" ; exit 1 ; }

--- a/7.5.2-simple/resource/opencms-run.sh
+++ b/7.5.2-simple/resource/opencms-run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# 
+
+# By default Tomcat will overwrite session cookies from multiple webapps on the same IP even different ports are used
+# With this little 'sed' magic, each running docker instance will attach the ID of the running container to the session cookie name 
+sed -i "s/<Context>/<Context sessionCookieName=\"JSESSIONID_$HOSTNAME\">/" /etc/tomcat7/context.xml
+
+# Make sure Tomcat has enough memory
+sed -i "s/JAVA_OPTS=\"-Djava.awt.headless=true -Xmx128m -XX:+UseConcMarkSweepGC\"/JAVA_OPTS=\"-Djava.awt.headless=true -Xms256m -Xmx1024m -XX:MaxPermSize=128m -server -XX:+UseConcMarkSweepGC\"/" /etc/default/tomcat7 
+
+# Start mySQL and Tomcat 
+service mysql start
+service tomcat7 start
+
+# Run SSH in "non-deamon" mode
+/usr/sbin/sshd -D
+


### PR DESCRIPTION
Hi,
  With reference to this: https://github.com/alkacon/opencms-docker/issues/1
  Apparently, we need to have this version as a docker image.
The following work-arounds were done:
1. This is constructed out of 9.5.2-simple as a base.
2. The opencms-app.zip and opencms.sql.zip is used as an alternative for opencms.war. Those zips are the ones created after installing 7.5.2 with the user interaction. The .sql is an mysql dump.

I have tried to retain the MAINTAINER etc. but do let me know if you cannot accept this pull request, then I can take it away as this cannot be official anymore.


Thanks,
 - Anoop