### PR TITLE
Upgrade base image

### DIFF
--- a/10.5.1/Dockerfile
+++ b/10.5.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 MAINTAINER Alkacon Software GmbH
 
 #


### PR DESCRIPTION
java:8-jre has been deprecated in favour of the openjdk:8-jre image. See
https://hub.docker.com/_/java/