### PR TITLE
Postgresql support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,36 +30,40 @@ Images for older OpenCms versions are also available, see [here](https://github.
 
 Save the following docker-compose.yml file to your host machine.
 
-```
-version: '3.7'
+```yaml
 services:
     mariadb:
         image: mariadb:latest
         container_name: mariadb
-        init: true
         restart: always
         volumes:
             - ~/dockermount/opencms-docker-mysql:/var/lib/mysql
         environment:
-            - "MYSQL_ROOT_PASSWORD=secretDBpassword"
+            - MYSQL_ROOT_PASSWORD=secretDBpassword
+            - TZ=Europe/Berlin
+
     opencms:
         image: alkacon/opencms-docker:15.0
         container_name: opencms
-        init: true
+        build: ./image
         restart: always
-        depends_on: [ "mariadb" ]
+        depends_on:
+            - mariadb
         links:
-            - "mariadb:mysql"
+            - mariadb:mysql
         ports:
-            - "80:8080"
+            - 80:8080
         volumes:
             - ~/dockermount/opencms-docker-webapps:/usr/local/tomcat/webapps
-        command: ["/root/wait-for.sh", "mysql:3306", "-t", "30", "--", "/root/opencms-run.sh"]
+        command: /root/wait-for.sh -t 30 -- /root/opencms-run.sh
         environment:
-             - "DB_PASSWD=secretDBpassword"
+            - DB_PASSWD=secretDBpassword
+            - TZ=Europe/Berlin
 ```
 
 Change the MariaDB root password `secretDBpassword`.
+
+Other example with PostgreSQL: [docker-compose-pgsql.yml](https://github.com/alkacon/opencms-docker/blob/master/docker-compose-pgsql.yml)
 
 ### Step 2: Persist data
 
@@ -90,7 +94,9 @@ The default account is user name `Admin` with password `admin`.
 
 In addition to `DB_PASSWD`, the following Docker Compose environment variables are honored:
 
+* `DB_PRODUCT`, type of the database, `mysql` or `postgresql`, defaults to `mysql`
 * `DB_HOST`, the database host name, defaults to `mysql`
+* `DB_PORT`, the database port number, defaults to `3306`
 * `DB_USER`, the database user, default is `root`
 * `DB_PASSWD`, the database password, is not set by default
 * `DB_NAME`, the database name, default is `opencms`
@@ -101,6 +107,7 @@ In addition to `DB_PASSWD`, the following Docker Compose environment variables a
 * `DEBUG`, flag indicating whether to enable verbose debug logging and allowing connections via {docker ip address}:8000, defaults to `false`
 * `JSONAPI`, flag indicating whether to enable the JSON API, default is `false`
 * `SERVER_URL`, the server URL, default is `http://localhost`
+* `TZ`, time zone identifier, defaults to `UTC`
 
 ## Upgrade the image
 

--- a/docker-compose-pgsql.yml
+++ b/docker-compose-pgsql.yml
@@ -1,28 +1,31 @@
 services:
-    mariadb:
-        image: mariadb:latest
-        container_name: mariadb
+    postgres:
+        image: postgres:12-alpine
+        container_name: postgres
         restart: always
         volumes:
-            - ~/dockermount/opencms-docker-mysql:/var/lib/mysql
+            ~/dockermount/opencms-docker-postgres:/var/lib/postgresql/data
         environment:
-            - MYSQL_ROOT_PASSWORD=secretDBpassword
             - TZ=Europe/Berlin
+            - POSTGRES_USER=postgres
+            - POSTGRES_PASSWORD=secretDBpassword
 
     opencms:
         image: alkacon/opencms-docker:15.0
         container_name: opencms
         build: ./image
         restart: always
-        depends_on:
-            - mariadb
-        links:
-            - mariadb:mysql
+        depends_on: 
+            - opencms_db
         ports:
             - 80:8080
         volumes:
             - ~/dockermount/opencms-docker-webapps:/usr/local/tomcat/webapps
         command: /root/wait-for.sh -t 30 -- /root/opencms-run.sh
         environment:
-            - DB_PASSWD=secretDBpassword
             - TZ=Europe/Berlin
+            - DB_PRODUCT=postgresql
+            - DB_HOST=postgres
+            - DB_PORT=5432
+            - DB_USER=postgres
+            - DB_PASSWD=secretDBpassword

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -19,11 +19,12 @@ ENV TOMCAT_LIB=${TOMCAT_HOME}/lib \
     OPENCMS_URL=http://www.opencms.org/downloads/opencms/opencms-15.0.zip \
     OPENCMS_COMPONENTS=workplace,demo \
     UPDATE_CONFIG_FILES="WEB-INF/web.xml WEB-INF/opencms.tld WEB-INF/config/opencms-search.xml WEB-INF/config/opencms-system.xml WEB-INF/config/opencms-vfs.xml WEB-INF/config/opencms-workplace.xml"\
-    TIME_ZONE=Europe/Berlin \
     TOMCAT_OPTS="-Xmx1g -Xms512m -server -XX:+UseConcMarkSweepGC" \
     GZIP=true \
     ADMIN_PASSWD=admin \
+    DB_PRODUCT=mysql \
     DB_HOST=mysql \
+    DB_PORT=3306 \
     DB_NAME=opencms \
     DB_USER=root \
     DB_PASSWD=\
@@ -50,5 +51,7 @@ RUN \
 
 # Expose port 8080 for Tomcat and define the startup script
 EXPOSE 8080
+
+VOLUME ${WEBAPPS_HOME}
 
 CMD ["/root/opencms-run.sh"]

--- a/image/resources/root/opencms-run.sh
+++ b/image/resources/root/opencms-run.sh
@@ -2,10 +2,6 @@
 
 # OpenCms startup script executed when Docker loads the image
 
-# Set the timezone
-echo "Adjusting the timezone"
-bash /root/set-timezone.sh ${TIME_ZONE}
-
 ls /root/preinit/
 
 chmod -v +x /root/preinit/*.sh

--- a/image/resources/root/preinit/10-create-setup-properties.sh
+++ b/image/resources/root/preinit/10-create-setup-properties.sh
@@ -6,9 +6,20 @@ HWADDR=$(cat /sys/class/net/eth0/address)
 DB_USER=$DB_USER
 DB_PWD=$DB_PASSWD
 DB_DB=$DB_NAME
-DB_PRODUCT=mysql
-DB_URL="jdbc:mysql://${DB_HOST}:3306/"
-DB_DRIVER=org.gjt.mm.mysql.Driver
+DB_PRODUCT=$DB_PRODUCT
+DB_URL="jdbc:${DB_PRODUCT}://${DB_HOST}:${DB_PORT}/"
+
+if [[ ${DB_PRODUCT} == "mysql" ]]; then
+    DB_DRIVER=org.mariadb.jdbc.Driver
+elif [[ ${DB_PRODUCT} == "postgresql" ]]; then
+    DB_DRIVER=org.postgresql.Driver
+    TEMPLATE_DB=template1
+    DB_WORKER_USER=opencms
+else
+    echo "Unknown DB: ${DB_PRODUCT}"
+    exit 1
+fi
+
 
 # Create setup.properties
 echo "OpenCms Setup: Writing configuration to '$CONFIG_FILE'"
@@ -24,7 +35,7 @@ db.product=$DB_PRODUCT
 db.provider=$DB_PRODUCT
 db.create.user=$DB_USER
 db.create.pwd=$DB_PWD
-db.worker.user=$DB_USER
+db.worker.user=${DB_WORKER_USER:-$DB_USER}
 db.worker.pwd=$DB_PWD
 db.connection.url=$DB_URL
 db.name=$DB_DB
@@ -34,7 +45,7 @@ db.dropDb=true
 db.default.tablespace=
 db.index.tablespace=
 db.jdbc.driver=$DB_DRIVER
-db.template.db=
+db.template.db=$TEMPLATE_DB
 db.temporary.tablespace=
 
 server.url=$OCSERVER

--- a/image/resources/root/set-timezone.sh
+++ b/image/resources/root/set-timezone.sh
@@ -1,1 +1,0 @@
-ln -snf /usr/share/zoneinfo/$1 /etc/localtime && echo $1 > /etc/timezone

--- a/image/resources/root/wait-for.sh
+++ b/image/resources/root/wait-for.sh
@@ -71,9 +71,15 @@ do
   esac
 done
 
+# Default to envvar:
+HOST="${HOST:-$DB_HOST}"
+PORT="${PORT:-$DB_PORT}"
+
 if [ "$HOST" = "" -o "$PORT" = "" ]; then
   echoerr "Error: you need to provide a host and port to test."
   usage 2
+else
+  echo "Waiting for ${HOST}:${PORT}"
 fi
 
 wait_for "$@"


### PR DESCRIPTION
Hello, and thank you for this project!

With his changes it's possible to run opencms_docker with postgresql db. All of the new options fallback to the previous value, so existing users shouldn't notice anything, the old compose file still works with same result.

Added docker compose example: `docker-compose-pgsql.yml`, updated README as well.

Other small fixes:

- `image/resources/root/wait-for.sh`:  made the `HOST:PORT` parameters optional, defaults to the `$DB_HOST:$DB_PORT` envvars. This way the user have to set only the `$DB_HOST` and `$DB_PORT` as envvars, no duplication needed on the `command` line.
- `image/Dockerfile`: [`VOLUME`](https://docs.docker.com/engine/reference/builder/#volume) instruction for better mounting.
- `docker-compose.yml`: A lot of old options, they are not needed anymore, the container runs and builds perfectly without them.
- `image/resources/root/opencms-run.sh`: Time zone can be applied by simply setting the `TZ` envvar, so these timezone related code is not necessary.

